### PR TITLE
fix/rpc-validateaddress

### DIFF
--- a/Breeze.BreezeServer/BreezeConfiguration.cs
+++ b/Breeze.BreezeServer/BreezeConfiguration.cs
@@ -82,6 +82,21 @@ namespace Breeze.BreezeServer
                 {
                     TumblerNetwork = Network.Main;
                 }
+
+                if (configFile.GetOrDefault<string>("network", "testnet").Equals("stratistest"))
+                {
+                    TumblerNetwork = Network.StratisTest;
+                }
+
+                if (configFile.GetOrDefault<string>("network", "testnet").Equals("stratisregtest"))
+                {
+                    TumblerNetwork = Network.StratisRegTest;
+                }
+
+                if (configFile.GetOrDefault<string>("network", "testnet").Equals("stratismain"))
+                {
+                    TumblerNetwork = Network.StratisMain;
+                }
                 
                 RpcUser = configFile.GetOrDefault<string>("rpc.user", null);
                 RpcPassword = configFile.GetOrDefault<string>("rpc.password", null);
@@ -140,7 +155,13 @@ namespace Breeze.BreezeServer
 
                 string bitcoinNetwork;
                 
-                if (TumblerNetwork == Network.Main)
+                if (TumblerNetwork == Network.StratisMain)
+                    bitcoinNetwork = "StratisMainNet";
+                else if (TumblerNetwork == Network.StratisTest)
+                    bitcoinNetwork = "StratisTest";
+                else if (TumblerNetwork == Network.StratisRegTest)
+                    bitcoinNetwork = "StratisRegTest";
+                else if (TumblerNetwork == Network.Main)
                     bitcoinNetwork = "MainNet";
                 else if (TumblerNetwork == Network.RegTest)
                     bitcoinNetwork = "RegTest";

--- a/Breeze.BreezeServer/Services/TumblerService.cs
+++ b/Breeze.BreezeServer/Services/TumblerService.cs
@@ -27,11 +27,17 @@ namespace Breeze.BreezeServer.Services
         {
             var argsTemp = new List<string>();
             argsTemp.Add("-debug");
-			
-			if (breezeConfig.TumblerNetwork == Network.TestNet)
-				argsTemp.Add("-testnet");
-			else if (breezeConfig.TumblerNetwork == Network.RegTest)
-			    argsTemp.Add("-regtest");
+
+            if (breezeConfig.TumblerNetwork == Network.TestNet)
+                argsTemp.Add("-testnet");
+            else if (breezeConfig.TumblerNetwork == Network.RegTest)
+                argsTemp.Add("-regtest");
+            else if (breezeConfig.TumblerNetwork == Network.StratisMain)
+                argsTemp.Add("-stratis");
+            else if (breezeConfig.TumblerNetwork == Network.StratisTest)
+                argsTemp.Add("-stratistest");
+            else if (breezeConfig.TumblerNetwork == Network.StratisRegTest)
+                argsTemp.Add("-stratisregtest");
             // No else needed, mainnet is defaulted
             
             if (ntumblebitServerConf != null)

--- a/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
@@ -115,6 +115,9 @@ namespace NTumbleBit.ClassicTumbler.Server
 
 			Network = args.Contains("-testnet", StringComparer.OrdinalIgnoreCase) ? Network.TestNet :
 				args.Contains("-regtest", StringComparer.OrdinalIgnoreCase) ? Network.RegTest :
+                args.Contains("-stratismain", StringComparer.OrdinalIgnoreCase) ? Network.StratisMain :
+                args.Contains("-stratistest", StringComparer.OrdinalIgnoreCase) ? Network.StratisTest :
+                args.Contains("-stratisregtest", StringComparer.OrdinalIgnoreCase) ? Network.StratisRegTest :
 				Network.Main;
 
 			if(ConfigurationFile != null)
@@ -124,6 +127,9 @@ namespace NTumbleBit.ClassicTumbler.Server
 				
 				Network = configTemp.GetOrDefault<bool>("testnet", false) ? Network.TestNet :
 						  configTemp.GetOrDefault<bool>("regtest", false) ? Network.RegTest :
+                          configTemp.GetOrDefault<bool>("stratismain", false) ? Network.StratisMain :
+                          configTemp.GetOrDefault<bool>("stratistest", false) ? Network.StratisTest :
+                          configTemp.GetOrDefault<bool>("stratisregtest", false) ? Network.StratisRegTest :
 						  Network.Main;
 			}
 			if(DataDir == null)

--- a/NTumbleBit/Configuration/RPCArgs.cs
+++ b/NTumbleBit/Configuration/RPCArgs.cs
@@ -83,7 +83,7 @@ namespace NTumbleBit.Configuration
 			try
 			{
 				var address = new Key().PubKey.GetAddress(network);
-				var isValid = ((JObject)rpcClient.SendCommand("validateaddress", address.ToString()).Result)["isvalid"].Value<bool>();
+				var isValid = rpcClient.ValidateAddress(address).IsValid;
 				if(!isValid)
 				{
 					Logs.Configuration.LogError("The RPC Server is on a different blockchain than the one configured for tumbling");


### PR DESCRIPTION
* Changes RPCArgs to use NBitcoin.RPCClient `ValidateAddress` 
* Breeze.BreezeServer now runs on SBFN/Stratis.StratisD until breaks on DumpPrivKey rpc
* **requires** changes from stratisplatform/StratisBitcoinFullNode#1047