### PR TITLE
New Testnet API Ports

### DIFF
--- a/Breeze.UI/main.ts
+++ b/Breeze.UI/main.ts
@@ -115,7 +115,7 @@ function closeBitcoinApi() {
     var http1 = require('http');
     const options1 = {
       hostname: 'localhost',
-      port: 37220,
+      port: 38220,
       path: '/api/node/shutdown',
       method: 'POST'
   };
@@ -132,7 +132,7 @@ function closeStratisApi() {
     var http2 = require('http');
     const options2 = {
       hostname: 'localhost',
-      port: 37221,
+      port: 38221,
       path: '/api/node/shutdown',
       method: 'POST'
     };

--- a/Breeze.UI/src/app/shared/services/api.service.ts
+++ b/Breeze.UI/src/app/shared/services/api.service.ts
@@ -27,9 +27,9 @@ export class ApiService {
 
     private headers = new Headers({'Content-Type': 'application/json'});
     private pollingInterval = 3000;
-    private bitcoinApiUrl = 'http://localhost:37220/api';
-    private stratisApiUrl = 'http://localhost:37221/api';
-    private currentApiUrl = 'http://localhost:37220/api';
+    private bitcoinApiUrl = 'http://localhost:38220/api';
+    private stratisApiUrl = 'http://localhost:38221/api';
+    private currentApiUrl = 'http://localhost:38220/api';
 
     private getCurrentCoin() {
       let currentCoin = this.globalService.getCoinName();

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
@@ -11,7 +11,7 @@ export class TumblebitService {
   // The service to connect to & operate a TumbleBit Server via the
   // TumbleBit.Client.CLI tool
 
-  private tumblerClientUrl = 'http://localhost:37220/api/TumbleBit/';
+  private tumblerClientUrl = 'http://localhost:38220/api/TumbleBit/';
   private headers = new Headers({ 'Content-Type': 'application/json' });
 
   private pollingInterval = 3000;


### PR DESCRIPTION

## Update testnet API ports per [c118ea2](https://github.com/stratisproject/StratisBitcoinFullNode/pull/1093/commits/c118ea24f85355a43553fd38de28e1939c580041)

Added ports 38220 and 38221 to be the API ports for bitcoin testnet and stratis testnet respectively.
This allows mainnet and a testnet nodes to be run at the same time on a single machine.

@dev0tion or @zeptin this PR can be committed when you guys are ready to update SBFN in this repo.