### PR TITLE
Revert Registrations back to Master-node block height

### DIFF
--- a/Breeze.Registration/RegistrationFeature.cs
+++ b/Breeze.Registration/RegistrationFeature.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Breeze.Registration/RegistrationFeature.cs
+++ b/Breeze.Registration/RegistrationFeature.cs
@@ -1,19 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Security.Principal;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NBitcoin.Protocol;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Configuration;
-using Stratis.Bitcoin.Features.Notifications;
-using Stratis.Bitcoin.Utilities;
 using BreezeCommon;
-using NBitcoin.Crypto;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Features.WatchOnlyWallet;
 using Stratis.Bitcoin.Features.Notifications.Interfaces;
@@ -23,14 +16,17 @@ namespace Breeze.Registration
 {
 	public class RegistrationFeature : FullNodeFeature
 	{
-        private ILogger logger;
+	    private const int SyncHeightMain = 772272;
+	    private const int SyncHeightTest = 335760;
+	    private const int SyncHeightRegTest = 0;
+	    private ILogger logger;
         private NodeSettings nodeSettings;
 		private RegistrationStore registrationStore;
         private readonly ConcurrentChain chain;
         private readonly Signals signals;
         private IWatchOnlyWalletManager watchOnlyWalletManager;
-	    private readonly BlockNotification blockNotification;
-		private IWalletSyncManager walletSyncManager;
+	    private readonly IBlockNotification blockNotification;
+	    private IWalletSyncManager walletSyncManager;
 
         private ILoggerFactory loggerFactory;
         private readonly IRegistrationManager registrationManager;
@@ -59,12 +55,12 @@ namespace Breeze.Registration
             this.signals = signals;
             this.network = nodeSettings.Network;
             this.watchOnlyWalletManager = watchOnlyWalletManager;
-		    this.blockNotification = blockNotification as BlockNotification;
-			this.walletSyncManager = walletSyncManager;
+		    this.blockNotification = blockNotification;
+		    this.walletSyncManager = walletSyncManager;
 
             if (nodeSettings.Network == Network.Main || nodeSettings.Network == Network.TestNet || nodeSettings.Network == Network.RegTest)
             {
-                // Bitcoin networks - these currently only interrogate the registration store for initial masternode selection
+                // Bitcoin networks - these currently only interrogate the registration store for initial master-node selection
                 this.isBitcoin = true;
             }
             else
@@ -79,54 +75,64 @@ namespace Breeze.Registration
 
 		public override void Initialize()
 		{
-            if (!this.isBitcoin)
-            {
-                // Start syncing from the height of the earliest possible registration transaction instead of the genesis block. This saves time.
-                this.logger.LogDebug("Registration: blockNotification.StartHash = " + this.blockNotification.StartHash);
-	            
-	            // Note that the headers (Headers.Height in console output) still need to sync first, which takes some
-	            // time. Once that height is reached the blocks begin being downloaded from that height in full.
-                if (this.blockNotification.StartHash == null)
-                {
-	                if (this.network == Network.StratisMain)
-	                {
-		                this.walletSyncManager.SyncFromHeight(772272); // 1175552642fb0881a8de4fbc7553e1fd112ced42e5ce192559fa41b25d897e2f
-					}
+		    if (!this.isBitcoin)
+                this.InitializeStratis();
 
-	                if (this.network == Network.StratisTest)
-	                {
-		                this.walletSyncManager.SyncFromHeight(335760); // 9997fb0d8d027fd95f6b36a3cea5c86e2926077cd430cef6b1ae735ddf7c5312
-					}
-
-	                // For regtest, it is not clear that re-issuing a sync command will be beneficial. Generally you want to sync from genesis in that case.
-                }
-
-	            // Verify that the registration store is in a consistent state on startup
-	            // The signatures of all the records need to be validated
-	            foreach (var registrationRecord in this.registrationStore.GetAll())
-	            {
-		            var registrationToken = registrationRecord.Record;
-
-		            if (!registrationToken.Validate(this.network))
-			            this.registrationStore.Delete(registrationRecord.RecordGuid);
-	            }
-
-	            // Only need to subscribe to receive blocks and transactions on the Stratis network
-                this.blockSubscriberdDisposable = this.signals.SubscribeForBlocks(new RegistrationBlockObserver(this.chain, this.registrationManager));
-                //this.transactionSubscriberdDisposable = this.signals.SubscribeForTransactions(new TransactionObserver(this.registrationManager));
-            }
-
-            this.registrationManager.Initialize(this.loggerFactory, this.registrationStore, this.isBitcoin, this.network, this.watchOnlyWalletManager);
+            this.registrationManager.Initialize(this.loggerFactory, 
+                this.registrationStore, 
+                this.isBitcoin, 
+                this.network, 
+                this.watchOnlyWalletManager);
         }
 
         public override void Dispose()
         {
             this.blockSubscriberdDisposable?.Dispose();
-            //this.transactionSubscriberdDisposable?.Dispose();
         }
+
+	    private void InitializeStratis()
+	    {
+	        this.logger.LogTrace("()");
+
+            IList<RegistrationRecord> registrationRecords = this.registrationStore.GetAll();
+
+            // If there are no registrations then revert back to the block height of when the MasterNodes were set-up.
+            if (registrationRecords.Count == 0)
+                RevertRegistrations();
+            else
+                VerifyRegistrationStore(registrationRecords);
+
+            // Only need to subscribe to receive blocks and transactions on the Stratis network
+            this.blockSubscriberdDisposable = this.signals.SubscribeForBlocks(new RegistrationBlockObserver(this.chain, this.registrationManager));
+
+            this.logger.LogTrace("(-)");
+        }
+
+	    private void RevertRegistrations()
+	    {
+	        this.logger.LogTrace("Registrations missing");
+
+	        // For regtest, it is not clear that re-issuing a sync command will be beneficial. Generally you want to sync from genesis in that case.
+	        var syncHeight = this.network == Network.StratisMain ? SyncHeightMain :
+	            this.network == Network.StratisTest ? SyncHeightTest : SyncHeightRegTest;
+
+	        this.logger.LogTrace("Sync wallet from : {0}", syncHeight);
+
+	        this.walletSyncManager.SyncFromHeight(syncHeight);
+	    }
+
+	    private void VerifyRegistrationStore(IList<RegistrationRecord> list)
+	    {
+	        // Verify that the registration store is in a consistent state on start-up.  The signatures of all the records need to be validated
+	        foreach (var registrationRecord in list)
+	        {
+	            if (!registrationRecord.Record.Validate(this.network))
+	                this.registrationStore.Delete(registrationRecord.RecordGuid);
+	        }
+	    }
     }
-    
-	public static class RegistrationFeatureExtension
+
+    public static class RegistrationFeatureExtension
 	{
 		public static IFullNodeBuilder UseRegistration(this IFullNodeBuilder fullNodeBuilder)
 		{

--- a/Breeze.Registration/RegistrationFeature.cs
+++ b/Breeze.Registration/RegistrationFeature.cs
@@ -14,18 +14,18 @@ using Stratis.Bitcoin.Features.Wallet.Interfaces;
 
 namespace Breeze.Registration
 {
-	public class RegistrationFeature : FullNodeFeature
-	{
-	    private const int SyncHeightMain = 772272;
-	    private const int SyncHeightTest = 335760;
-	    private const int SyncHeightRegTest = 0;
-	    private readonly ILogger logger;
-		private readonly RegistrationStore registrationStore;
+    public class RegistrationFeature : FullNodeFeature
+    {
+        private const int SyncHeightMain = 772272;
+        private const int SyncHeightTest = 335760;
+        private const int SyncHeightRegTest = 0;
+        private readonly ILogger logger;
+        private readonly RegistrationStore registrationStore;
         private readonly ConcurrentChain chain;
         private readonly Signals signals;
         private readonly IWatchOnlyWalletManager watchOnlyWalletManager;
-	    private readonly IBlockNotification blockNotification;
-	    private readonly IWalletSyncManager walletSyncManager;
+        private readonly IBlockNotification blockNotification;
+        private readonly IWalletSyncManager walletSyncManager;
 
         private readonly ILoggerFactory loggerFactory;
         private readonly IRegistrationManager registrationManager;
@@ -42,20 +42,21 @@ namespace Breeze.Registration
             Signals signals,
             IWatchOnlyWalletManager watchOnlyWalletManager,
             IBlockNotification blockNotification,
-	        IWalletSyncManager walletSyncManager)
-		{
+            IWalletSyncManager walletSyncManager)
+        {
             this.loggerFactory = loggerFactory;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.registrationManager = registrationManager;
-			this.registrationStore = registrationStore;
+            this.registrationStore = registrationStore;
             this.chain = chain;
             this.signals = signals;
             this.network = nodeSettings.Network;
             this.watchOnlyWalletManager = watchOnlyWalletManager;
-		    this.blockNotification = blockNotification;
-		    this.walletSyncManager = walletSyncManager;
+            this.blockNotification = blockNotification;
+            this.walletSyncManager = walletSyncManager;
 
-            if (nodeSettings.Network == Network.Main || nodeSettings.Network == Network.TestNet || nodeSettings.Network == Network.RegTest)
+            if (nodeSettings.Network == Network.Main || nodeSettings.Network == Network.TestNet ||
+                nodeSettings.Network == Network.RegTest)
             {
                 // Bitcoin networks - these currently only interrogate the registration store for initial master-node selection
                 this.isBitcoin = true;
@@ -68,14 +69,15 @@ namespace Breeze.Registration
                 // Force registration store to be kept in same folder as other node data
                 this.registrationStore.SetStorePath(nodeSettings.DataDir);
             }
-		}
+        }
 
-		public override void Initialize()
-		{
-		    if (!this.isBitcoin)
+        public override void Initialize()
+        {
+            if (!this.isBitcoin)
                 this.InitializeStratis();
 
-            this.registrationManager.Initialize(this.loggerFactory, this.registrationStore, this.isBitcoin, this.network, this.watchOnlyWalletManager);
+            this.registrationManager.Initialize(this.loggerFactory, this.registrationStore, this.isBitcoin,
+                this.network, this.watchOnlyWalletManager);
         }
 
         public override void Dispose()
@@ -83,77 +85,78 @@ namespace Breeze.Registration
             this.blockSubscriberdDisposable?.Dispose();
         }
 
-	    private void InitializeStratis()
-	    {
-	        this.logger.LogTrace("()");
+        private void InitializeStratis()
+        {
+            this.logger.LogTrace("()");
 
             IList<RegistrationRecord> registrationRecords = this.registrationStore.GetAll();
 
             // If there are no registrations then revert back to the block height of when the MasterNodes were set-up.
-	        if (registrationRecords.Count == 0)
-	            RevertRegistrations();
-	        else
+            if (registrationRecords.Count == 0)
+                RevertRegistrations();
+            else
                 VerifyRegistrationStore(registrationRecords);
 
-	        // Only need to subscribe to receive blocks and transactions on the Stratis network
-            this.blockSubscriberdDisposable = this.signals.SubscribeForBlocks(new RegistrationBlockObserver(this.chain, this.registrationManager));
+            // Only need to subscribe to receive blocks and transactions on the Stratis network
+            this.blockSubscriberdDisposable =
+                this.signals.SubscribeForBlocks(new RegistrationBlockObserver(this.chain, this.registrationManager));
 
             this.logger.LogTrace("(-)");
         }
 
-	    private void RevertRegistrations()
-	    {
-	        this.logger.LogTrace("()");
+        private void RevertRegistrations()
+        {
+            this.logger.LogTrace("()");
 
-	        this.logger.LogTrace("Registrations missing");
+            this.logger.LogTrace("Registrations missing");
 
-	        // For RegTest, it is not clear that re-issuing a sync command will be beneficial. Generally you want to sync from genesis in that case.
-	        var syncHeight = this.network == Network.StratisMain ? SyncHeightMain :
-	            this.network == Network.StratisTest ? SyncHeightTest : SyncHeightRegTest;
+            // For RegTest, it is not clear that re-issuing a sync command will be beneficial. Generally you want to sync from genesis in that case.
+            var syncHeight = this.network == Network.StratisMain ? SyncHeightMain :
+                this.network == Network.StratisTest ? SyncHeightTest : SyncHeightRegTest;
 
-	        this.logger.LogTrace("Sync wallet from : {0}", syncHeight);
+            this.logger.LogTrace("Sync wallet from : {0}", syncHeight);
 
-	        this.walletSyncManager.SyncFromHeight(syncHeight);
+            this.walletSyncManager.SyncFromHeight(syncHeight);
 
-	        this.logger.LogTrace("(-)");
+            this.logger.LogTrace("(-)");
         }
 
-	    private void VerifyRegistrationStore(IList<RegistrationRecord> list)
-	    {
-	        this.logger.LogTrace("()");
+        private void VerifyRegistrationStore(IList<RegistrationRecord> list)
+        {
+            this.logger.LogTrace("()");
 
             this.logger.LogTrace("VerifyRegistrationStore");
 
             // Verify that the registration store is in a consistent state on start-up.  The signatures of all the records need to be validated
             foreach (var registrationRecord in list)
-	        {
-	            if (registrationRecord.Record.Validate(this.network)) continue;
+            {
+                if (registrationRecord.Record.Validate(this.network)) continue;
 
-	            this.logger.LogTrace("Deleting invalid registration : {0}", registrationRecord.RecordGuid);
+                this.logger.LogTrace("Deleting invalid registration : {0}", registrationRecord.RecordGuid);
 
-	            this.registrationStore.Delete(registrationRecord.RecordGuid);
-	        }
+                this.registrationStore.Delete(registrationRecord.RecordGuid);
+            }
 
-	        this.logger.LogTrace("(-)");
+            this.logger.LogTrace("(-)");
         }
     }
 
     public static class RegistrationFeatureExtension
-	{
-		public static IFullNodeBuilder UseRegistration(this IFullNodeBuilder fullNodeBuilder)
-		{
-			fullNodeBuilder.ConfigureFeature(features =>
-			{
-				features
-					.AddFeature<RegistrationFeature>()
-					.FeatureServices(services =>
-					{
-						services.AddSingleton<RegistrationStore>();
+    {
+        public static IFullNodeBuilder UseRegistration(this IFullNodeBuilder fullNodeBuilder)
+        {
+            fullNodeBuilder.ConfigureFeature(features =>
+            {
+                features
+                    .AddFeature<RegistrationFeature>()
+                    .FeatureServices(services =>
+                    {
+                        services.AddSingleton<RegistrationStore>();
                         services.AddSingleton<RegistrationManager>();
                     });
-			});
+            });
 
-			return fullNodeBuilder;
-		}
-	}
+            return fullNodeBuilder;
+        }
+    }
 }


### PR DESCRIPTION
Revert Registrations back to Master-node block height (Main, Test, RegTest), when the registrationHistory.json is empty.

Fix Product Backlog Item 1084: No MasterNode registrations are available.