### PR TITLE
1387 Alert if tor not running in UI

### DIFF
--- a/Breeze.UI/package.json
+++ b/Breeze.UI/package.json
@@ -63,7 +63,7 @@
     "zone.js": "0.8.18"
   },
   "devDependencies": {
-    "@angular/cli": "1.6.0",
+    "@angular/cli": "^1.7.4",
     "@angular/compiler-cli": "5.1.0",
     "@angular/language-service": "5.1.0",
     "@types/core-js": "0.9.36",
@@ -105,6 +105,7 @@
     "npx": "9.7.1",
     "postcss-loader": "2.0.9",
     "postcss-url": "7.3.0",
+    "postcss-custom-properties": "7.0.0",
     "protractor": "5.2.1",
     "raw-loader": "0.5.1",
     "sass-loader": "6.0.6",

--- a/Breeze.UI/src/app/app.module.ts
+++ b/Breeze.UI/src/app/app.module.ts
@@ -5,9 +5,9 @@ import { HttpModule } from '@angular/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ClipboardModule } from 'ngx-clipboard';
+import { RouterModule, RouteReuseStrategy } from '@angular/router';
 
 import { SharedModule } from './shared/shared.module';
-
 import { AppRoutingModule } from './app-routing.module';
 
 import { AppComponent } from './app.component';
@@ -29,6 +29,7 @@ import { TransactionDetailsComponent } from './wallet/transaction-details/transa
 import { PasswordConfirmationComponent } from './wallet/tumblebit/password-confirmation/password-confirmation.component';
 import { LogoutConfirmationComponent } from './wallet/logout-confirmation/logout-confirmation.component';
 
+import { CustomReuseStrategy } from './reuse-strategy';
 
 @NgModule({
   imports: [
@@ -39,6 +40,7 @@ import { LogoutConfirmationComponent } from './wallet/logout-confirmation/logout
     ReactiveFormsModule,
     FormsModule,
     HttpModule,
+    RouterModule,
     NgbModule.forRoot(),
     SharedModule.forRoot()
   ],
@@ -66,7 +68,8 @@ import { LogoutConfirmationComponent } from './wallet/logout-confirmation/logout
     TransactionDetailsComponent,
     LogoutConfirmationComponent
   ],
-  providers: [ ApiService, GlobalService, ModalService, Title, TumblebitService ],
+  providers: [ ApiService, GlobalService, ModalService, Title, TumblebitService,
+    { provide: RouteReuseStrategy, useClass: CustomReuseStrategy } ],
   bootstrap: [ AppComponent ]
 })
 

--- a/Breeze.UI/src/app/reuse-strategy.ts
+++ b/Breeze.UI/src/app/reuse-strategy.ts
@@ -1,0 +1,32 @@
+import { RouteReuseStrategy, DetachedRouteHandle } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+
+export class CustomReuseStrategy implements RouteReuseStrategy {
+
+    handlers: { [key: string]: DetachedRouteHandle } = {};
+  
+    shouldDetach(route: ActivatedRouteSnapshot): boolean {
+      return route.data.shouldReuse || false;
+    }
+  
+    store(route: ActivatedRouteSnapshot, handle: {}): void {
+      if (route.data.shouldReuse) {
+        this.handlers[route.routeConfig.path] = handle;
+      }
+    }
+  
+    shouldAttach(route: ActivatedRouteSnapshot): boolean {
+      return !!route.routeConfig && !!this.handlers[route.routeConfig.path];
+    }
+  
+    retrieve(route: ActivatedRouteSnapshot): {} {
+      if (!route.routeConfig) return null;
+      return this.handlers[route.routeConfig.path];
+    }
+  
+    shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
+      return future.data.shouldReuse || false;
+    }
+  
+  }
+  

--- a/Breeze.UI/src/app/shared/classes/composite-disposable.ts
+++ b/Breeze.UI/src/app/shared/classes/composite-disposable.ts
@@ -1,0 +1,14 @@
+import { Subscription } from 'rxJs/Subscription';
+
+export class CompositeDisposable {
+    private _subscriptions: Set<Subscription> = new Set<Subscription>();
+    constructor(private subscriptions: Subscription[]) {
+        subscriptions.forEach(x => this.add(x));
+    }
+    add(subscription: Subscription): void {
+        this._subscriptions.add(subscription);
+    }
+    unsubscribe() {
+        this._subscriptions.forEach(x => x.unsubscribe());
+    }
+}

--- a/Breeze.UI/src/app/wallet/wallet-routing.module.ts
+++ b/Breeze.UI/src/app/wallet/wallet-routing.module.ts
@@ -12,9 +12,9 @@ const routes: Routes = [
   { path: '', component: WalletComponent,
     children: [
       { path: '', redirectTo:'dashboard', pathMatch:'full' },
-      { path: 'dashboard', component: DashboardComponent},
-      { path: 'privacy', component: TumblebitComponent},
-      { path: 'history', component: HistoryComponent}
+      { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: true } },
+      { path: 'privacy', component: TumblebitComponent, data: { shouldReuse: true } },
+      { path: 'history', component: HistoryComponent, data: { shouldReuse: true } }
     ]
   },
   { path: 'stratis-wallet', component: WalletComponent,


### PR DESCRIPTION
Dashboard, History and Privacy tabs are associated with their own components, and during this task I discovered that these components are created each time the tab is selected, which is bad - it's also related to _1387 Alert if tor not running in UI_.

The privacy tab's component (tumblebit.component) now checks Tor each time it's navigated to.

@DanGould 