### PR TITLE
332 - Disallow picking same source and destination wallet

### DIFF
--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -518,6 +518,13 @@ export class TumblebitComponent implements OnInit, OnDestroy {
     ;
   };
 
+  private removeSourceWallet() {
+    const index = this.wallets.indexOf(this.globalService.getWalletName());
+    if (index >= 0) {
+      this.wallets.splice(index, 1);
+    }
+  }
+
   private getWalletFiles() {
     this.apiService.getWalletFiles()
       .subscribe(
@@ -531,6 +538,9 @@ export class TumblebitComponent implements OnInit, OnDestroy {
                   this.wallets[wallet] = this.wallets[wallet].slice(0, -12);
                 }
               }
+
+              this.removeSourceWallet();
+
               // this.updateWalletFileDisplay(this.wallets[0]);
             } else {
             }

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -519,9 +519,9 @@ export class TumblebitComponent implements OnInit, OnDestroy {
   };
 
   private removeSourceWallet() {
-    const index = this.wallets.indexOf(this.globalService.getWalletName());
-    if (index >= 0) {
-      this.wallets.splice(index, 1);
+    const sourceWalletIndex = this.wallets.indexOf(this.globalService.getWalletName());
+    if (sourceWalletIndex >= 0) {
+      this.wallets.splice(sourceWalletIndex, 1);
     }
   }
 


### PR DESCRIPTION
The source wallet name is now removed from the destination wallet dropdown in the Privacy tab.

@DanGould @fenix2222 