### PR TITLE
Changed wallet-routing.module to only reuse the Privacy route.

### DIFF
--- a/Breeze.UI/src/app/wallet/wallet-routing.module.ts
+++ b/Breeze.UI/src/app/wallet/wallet-routing.module.ts
@@ -20,7 +20,7 @@ const routes: Routes = [
   { path: 'stratis-wallet', component: WalletComponent,
   children: [
     { path: '', redirectTo:'dashboard', pathMatch:'full' },
-    { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: false },
+    { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: false } },
     { path: 'history', component: HistoryComponent, data: { shouldReuse: false } }
   ]
 }

--- a/Breeze.UI/src/app/wallet/wallet-routing.module.ts
+++ b/Breeze.UI/src/app/wallet/wallet-routing.module.ts
@@ -12,16 +12,16 @@ const routes: Routes = [
   { path: '', component: WalletComponent,
     children: [
       { path: '', redirectTo:'dashboard', pathMatch:'full' },
-      { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: true } },
+      { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: false } },
       { path: 'privacy', component: TumblebitComponent, data: { shouldReuse: true } },
-      { path: 'history', component: HistoryComponent, data: { shouldReuse: true } }
+      { path: 'history', component: HistoryComponent, data: { shouldReuse: false } }
     ]
   },
   { path: 'stratis-wallet', component: WalletComponent,
   children: [
     { path: '', redirectTo:'dashboard', pathMatch:'full' },
-    { path: 'dashboard', component: DashboardComponent},
-    { path: 'history', component: HistoryComponent}
+    { path: 'dashboard', component: DashboardComponent, data: { shouldReuse: false },
+    { path: 'history', component: HistoryComponent, data: { shouldReuse: false } }
   ]
 }
 ];


### PR DESCRIPTION
Previously, all associated tab components were being reused - we only want the Privacy tab to be reused.

@carlton355 