### PR TITLE
Cannot Tumble (VSTS #1391) - Connection logic fix

### DIFF
--- a/Breeze.TumbleBit.Client/ITumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/ITumbleBitManager.cs
@@ -15,7 +15,7 @@ namespace Breeze.TumbleBit.Client
         /// <summary>
         /// Connects to a masternode running the Breeze Privacy Protocol.
         /// </summary>
-        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(List<String> masternodeBlacklist = null);
+        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<String> masternodeBlacklist = null);
 
 		/// <summary>
 		/// Disconnects from the currently connected masternode and attempts to connect to a new one.

--- a/Breeze.TumbleBit.Client/ITumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/ITumbleBitManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Breeze.TumbleBit.Client.Models;
 using NBitcoin;
@@ -14,7 +15,7 @@ namespace Breeze.TumbleBit.Client
         /// <summary>
         /// Connects to a masternode running the Breeze Privacy Protocol.
         /// </summary>
-        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync();
+        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(List<String> masternodeBlacklist = null);
 
 		/// <summary>
 		/// Disconnects from the currently connected masternode and attempts to connect to a new one.

--- a/Breeze.TumbleBit.Client/ITumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/ITumbleBitManager.cs
@@ -15,7 +15,7 @@ namespace Breeze.TumbleBit.Client
         /// <summary>
         /// Connects to a masternode running the Breeze Privacy Protocol.
         /// </summary>
-        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<String> masternodeBlacklist = null);
+        Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<string> masternodeBlacklist = null);
 
 		/// <summary>
 		/// Disconnects from the currently connected masternode and attempts to connect to a new one.

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -361,7 +361,7 @@ namespace Breeze.TumbleBit.Client
 
                     //Do not attempt a connection to the Masternode which is blacklisted
                     if (masternodeBlacklist != null && masternodeBlacklist.Contains(this.TumblerAddress)) {
-                        this.logger.LogDebug($"Skiping connection attempt to blacklisted masternode {this.TumblerAddress}");
+                        this.logger.LogDebug($"Skipping connection attempt to blacklisted masternode {this.TumblerAddress}");
                         continue;
                     }
 
@@ -381,7 +381,7 @@ namespace Breeze.TumbleBit.Client
                 }
 
                 // If we reach this point, no servers were reachable.
-                this.logger.LogDebug($"Attepmted connection to {registrations.Count} masternodes and did not find a valid registration");
+                this.logger.LogDebug($"Attempted connection to {registrations.Count} masternodes and did not find a valid registration");
                 return Result.Fail<ClassicTumblerParameters>("Did not find a valid registration");
             }
             else
@@ -454,7 +454,7 @@ namespace Breeze.TumbleBit.Client
 
         private async Task<Result<ClassicTumblerParameters>> TryUseServer()
         {
-            logger.LogWarning($"Attempting connection to the masternode at address {this.TumblerAddress}");
+            logger.LogInformation($"Attempting connection to the masternode at address {this.TumblerAddress}");
 
             this.tumblingState.TumblerUri = new Uri(this.TumblerAddress);
 

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -336,46 +336,78 @@ namespace Breeze.TumbleBit.Client
         }
 
         /// <inheritdoc />
-        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync()
+        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(List<String> masternodeBlacklist = null)
         {
             // Assumptions about the current state coming into this method:
             // - If this is a first connection, this.TumblerAddress will be null
             // - If we were previously connected to a server, its URI would have been stored in the
             //   tumbling_state.json, and will have been loaded into this.TumblerAddress already
-
-            // If the -ppuri command line option wasn't used to bypass the registration store lookup
             if (this.TumblerAddress == null)
             {
                 List<RegistrationRecord> registrations = this.registrationStore.GetAll();
 
                 if (registrations.Count < MINIMUM_MASTERNODE_COUNT)
                 {
-                    this.logger.LogDebug("Not enough masternode registrations downloaded yet: " + registrations.Count);
+                    this.logger.LogDebug($"Not enough masternode registrations downloaded yet: {registrations.Count}");
                     return Result.Fail<ClassicTumblerParameters>("Not enough masternode registrations downloaded yet");
                 }
-                
+
                 registrations.Shuffle();
 
-                // Since the list is shuffled, we can simply iterate through it and try each server until one is valid & reachable
+                // Since the list is shuffled, we can simply iterate through it and try each server until one is valid & reachable.
                 foreach (RegistrationRecord record in registrations)
                 {
-                    this.TumblerAddress = "ctb://" + record.Record.OnionAddress + ".onion?h=" + record.Record.ConfigurationHash;
+                    this.TumblerAddress = $"ctb://{record.Record.OnionAddress}.onion?h={record.Record.ConfigurationHash}";
 
-                    var attemptConnection = await TryUseServer();
+                    //Do not attempt a connection to the Masternode which is blacklisted
+                    if (masternodeBlacklist != null && masternodeBlacklist.Contains(this.TumblerAddress)) {
+                        this.logger.LogDebug($"Skiping connection attempt to blacklisted masternode {this.TumblerAddress}");
+                        continue;
+                    }
 
-                    if (!attemptConnection.Failure)
+                    try
                     {
-                        return attemptConnection;
+                        var tumblerParameterResult = await TryUseServer();
+
+                        if (tumblerParameterResult.Success)
+                        {
+                            return tumblerParameterResult;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        this.logger.LogDebug(e, $"Unable to connect to masternode: {this.TumblerAddress}");
                     }
                 }
 
-                // If we reach this point, no servers were reachable
-                this.logger.LogDebug("Did not find a valid registration");
+                // If we reach this point, no servers were reachable.
+                this.logger.LogDebug($"Attepmted connection to {registrations.Count} masternodes and did not find a valid registration");
                 return Result.Fail<ClassicTumblerParameters>("Did not find a valid registration");
             }
             else
             {
-                return await TryUseServer();
+                try
+                {
+                    var tumblerParameterResult = await TryUseServer();
+
+                    if (tumblerParameterResult.Success)
+                    {
+                        return tumblerParameterResult;
+                    }
+                }
+                catch (Exception e)
+                {
+                    this.logger.LogDebug(e, $"Unable to connect to masternode: {this.TumblerAddress}");
+                }
+
+                // Blacklist masternode address which we have just failed to connect to so that
+                // we won't attempt to connect to it again in the next call to ConnectToTumblerAsync.
+                List<String> blacklistedMasternodes = new List<String>() { this.TumblerAddress };
+
+                // The masternode that was being used in a previous run is now unreachable.
+                // Restart the connection process and try to find a working server.
+                this.TumblerAddress = null;
+                return await ConnectToTumblerAsync();
             }
         }
 
@@ -422,6 +454,8 @@ namespace Breeze.TumbleBit.Client
 
         private async Task<Result<ClassicTumblerParameters>> TryUseServer()
         {
+            logger.LogWarning($"Attempting connection to the masternode at address {this.TumblerAddress}");
+
             this.tumblingState.TumblerUri = new Uri(this.TumblerAddress);
 
             FullNodeTumblerClientConfiguration config;

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -336,7 +336,7 @@ namespace Breeze.TumbleBit.Client
         }
 
         /// <inheritdoc />
-        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<String> masternodeBlacklist = null)
+        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<string> masternodeBlacklist = null)
         {
             // Assumptions about the current state coming into this method:
             // - If this is a first connection, this.TumblerAddress will be null
@@ -380,7 +380,6 @@ namespace Breeze.TumbleBit.Client
                     }
                 }
 
-                // If we reach this point, no servers were reachable.
                 this.logger.LogDebug($"Attempted connection to {registrations.Count} masternodes and did not find a valid registration");
                 return Result.Fail<ClassicTumblerParameters>("Did not find a valid registration");
             }
@@ -402,12 +401,12 @@ namespace Breeze.TumbleBit.Client
 
                 // Blacklist masternode address which we have just failed to connect to so that
                 // we won't attempt to connect to it again in the next call to ConnectToTumblerAsync.
-                HashSet<String> blacklistedMasternodes = new HashSet<String>() { this.TumblerAddress };
+                HashSet<string> blacklistedMasternodes = new HashSet<string>() { this.TumblerAddress };
 
                 // The masternode that was being used in a previous run is now unreachable.
                 // Restart the connection process and try to find a working server.
                 this.TumblerAddress = null;
-                return await ConnectToTumblerAsync();
+                return await ConnectToTumblerAsync(blacklistedMasternodes);
             }
         }
 

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -336,7 +336,7 @@ namespace Breeze.TumbleBit.Client
         }
 
         /// <inheritdoc />
-        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(List<String> masternodeBlacklist = null)
+        public async Task<Result<ClassicTumblerParameters>> ConnectToTumblerAsync(HashSet<String> masternodeBlacklist = null)
         {
             // Assumptions about the current state coming into this method:
             // - If this is a first connection, this.TumblerAddress will be null
@@ -402,7 +402,7 @@ namespace Breeze.TumbleBit.Client
 
                 // Blacklist masternode address which we have just failed to connect to so that
                 // we won't attempt to connect to it again in the next call to ConnectToTumblerAsync.
-                List<String> blacklistedMasternodes = new List<String>() { this.TumblerAddress };
+                HashSet<String> blacklistedMasternodes = new HashSet<String>() { this.TumblerAddress };
 
                 // The masternode that was being used in a previous run is now unreachable.
                 // Restart the connection process and try to find a working server.


### PR DESCRIPTION
Modified the logic in ConnectToTumblerAsync method to attempt a connection to a different masternode if the connection stored in config file is not reachable.