### PR TITLE
Change number of connection retry in MasterNode connection tester

### DIFF
--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -71,7 +71,7 @@ namespace NTumbleBit.ClassicTumbler.Client
                 else if (configuration.TorMandatory)
                     throw new ConfigException("The tumbler server should use TOR");
                 var client = CreateTumblerClient(0);
-                TumblerParameters = Retry(3, () => client.GetTumblerParameters());
+                TumblerParameters = Retry(1, () => client.GetTumblerParameters());
                 if (TumblerParameters == null)
                     throw new ConfigException("Unable to download tumbler's parameters");                
                 return;


### PR DESCRIPTION
When we connect to MasterNodes for the first time using the "connection tester" we retry up to 3 times. Given that each failed connection attempt is taking at least 100sec we need 5min (3 x 100 sec) to prove that one MasterNode is unreachable. That would mean that we test 2 MasterNode within the 10min timeout set out in the Breeze GUI