### PR TITLE
Fixed issue with ChangeServer and reduced timeout for the MasterNode connection test

### DIFF
--- a/Breeze.Registration/RegistrationFeature.cs
+++ b/Breeze.Registration/RegistrationFeature.cs
@@ -108,13 +108,11 @@ namespace Breeze.Registration
         {
             this.logger.LogTrace("()");
 
-            this.logger.LogTrace("Registrations missing");
-
             // For RegTest, it is not clear that re-issuing a sync command will be beneficial. Generally you want to sync from genesis in that case.
             var syncHeight = this.network == Network.StratisMain ? SyncHeightMain :
                 this.network == Network.StratisTest ? SyncHeightTest : SyncHeightRegTest;
 
-            this.logger.LogTrace("Sync wallet from : {0}", syncHeight);
+            this.logger.LogTrace("Syncing from height {0} in order to get masternode registrations", syncHeight);
 
             this.walletSyncManager.SyncFromHeight(syncHeight);
 
@@ -127,7 +125,7 @@ namespace Breeze.Registration
 
             this.logger.LogTrace("VerifyRegistrationStore");
 
-            // Verify that the registration store is in a consistent state on start-up.  The signatures of all the records need to be validated
+            // Verify that the registration store is in a consistent state on start-up. The signatures of all the records need to be validated.
             foreach (var registrationRecord in list)
             {
                 if (registrationRecord.Record.Validate(this.network)) continue;

--- a/Breeze.Registration/RegistrationFeature.cs
+++ b/Breeze.Registration/RegistrationFeature.cs
@@ -112,7 +112,7 @@ namespace Breeze.Registration
             var syncHeight = this.network == Network.StratisMain ? SyncHeightMain :
                 this.network == Network.StratisTest ? SyncHeightTest : SyncHeightRegTest;
 
-            this.logger.LogTrace("Syncing from height {0} in order to get masternode registrations", syncHeight);
+            this.logger.LogInformation("Syncing from height {0} in order to get masternode registrations", syncHeight);
 
             this.walletSyncManager.SyncFromHeight(syncHeight);
 

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -421,34 +421,14 @@ namespace Breeze.TumbleBit.Client
 
             this.State = TumbleState.OnlyMonitor;
 
-            // Now select a different masternode
-            List<RegistrationRecord> registrations = this.registrationStore.GetAll();
+            // Blacklist masternode address which we are currently connected to so that
+            // we won't attempt to connect to it again in the next call to ConnectToTumblerAsync.
+            HashSet<string> blacklistedMasternodes = new HashSet<string>() { this.TumblerAddress };
 
-            if (registrations.Count < MINIMUM_MASTERNODE_COUNT)
-            {
-                this.logger.LogDebug("Not enough masternode registrations downloaded yet: " + registrations.Count);
-                return Result.Fail<ClassicTumblerParameters>("Not enough masternode registrations downloaded yet");
-            }
-
-            registrations.Shuffle();
-
-            // Since the list is shuffled, we can simply try the first one in the list.
-            // Unlike the connect method, we only try one server here. That is because
-            // a timeout can take in the order of minutes for each server tried.
-            RegistrationRecord record = registrations.First();
-
-            this.TumblerAddress = "ctb://" + record.Record.OnionAddress + ".onion?h=" + record.Record.ConfigurationHash;
-
-            var attemptConnection = await TryUseServer();
-
-            if (!attemptConnection.Failure)
-            {
-                return attemptConnection;
-            }
-
-            // If we reach this point, the server was unreachable
-            this.logger.LogDebug("Failed to connect to server, try another");
-            return Result.Fail<ClassicTumblerParameters>("Failed to connect to server, try another");
+            // The masternode that was being used in a previous run is now unreachable.
+            // Restart the connection process and try to find a working server.
+            this.TumblerAddress = null;
+            return await ConnectToTumblerAsync(blacklistedMasternodes);
         }
 
         private async Task<Result<ClassicTumblerParameters>> TryUseServer()

--- a/Breeze/src/Breeze.Daemon/Program.cs
+++ b/Breeze/src/Breeze.Daemon/Program.cs
@@ -155,8 +155,8 @@ namespace Breeze.Daemon
                 {"Microsoft.AspNetCore", Microsoft.Extensions.Logging.LogLevel.Error},
                 {"Stratis.Bitcoin", Microsoft.Extensions.Logging.LogLevel.Information},
 	            {"Stratis.Bitcoin.Features.WatchOnlyWallet.WatchOnlyWalletManager", Microsoft.Extensions.Logging.LogLevel.Information},
-				{"Breeze.TumbleBit.Client", Microsoft.Extensions.Logging.LogLevel.Debug},
-                {"Breeze.Registration", Microsoft.Extensions.Logging.LogLevel.Debug}
+				{"Breeze.TumbleBit.Client", Microsoft.Extensions.Logging.LogLevel.Information},
+                {"Breeze.Registration", Microsoft.Extensions.Logging.LogLevel.Information}
             };
             
             ConsoleLoggerSettings settings = nodeSettings.LoggerFactory.GetConsoleSettings();

--- a/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/ConnectionSettings.cs
+++ b/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/ConnectionSettings.cs
@@ -1,4 +1,5 @@
 ﻿using NTumbleBit.Configuration;
+using NTumbleBit.Tor;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -20,7 +21,7 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 			}
 			else if(type.Equals("socks", StringComparison.OrdinalIgnoreCase))
 			{
-				SocksConnectionSettings settings = new SocksConnectionSettings();
+                SocksConnectionSettings settings = new SocksConnectionSettings();
 				var server = config.GetOrDefault<IPEndPoint>(prefix + ".proxy.server", new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9050));
 				settings.Proxy = server;
 				return settings;
@@ -28,9 +29,11 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 			else
 				throw new ConfigException(prefix + ".proxy.type is not supported, should be socks or http");
 		}
-		public virtual HttpMessageHandler CreateHttpHandler()
+		public virtual HttpMessageHandler CreateHttpHandler(TimeSpan? connectTimeout)
 		{
-			return new TCPHttpMessageHandler(new ClientOptions() { IncludeHeaders = false });
+			var handler = new TCPHttpMessageHandler(new ClientOptions() { IncludeHeaders = false });
+            if (connectTimeout != null) handler.Options.ConnectTimeout = connectTimeout.Value;
+            return handler;
 		}
 	}
 }

--- a/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/ConnectionSettings.cs
+++ b/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/ConnectionSettings.cs
@@ -32,7 +32,10 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 		public virtual HttpMessageHandler CreateHttpHandler(TimeSpan? connectTimeout)
 		{
 			var handler = new TCPHttpMessageHandler(new ClientOptions() { IncludeHeaders = false });
-            if (connectTimeout != null) handler.Options.ConnectTimeout = connectTimeout.Value;
+
+            if (connectTimeout != null)
+                handler.Options.ConnectTimeout = connectTimeout.Value;
+
             return handler;
 		}
 	}

--- a/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/SocksConnectionSettings.cs
+++ b/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/SocksConnectionSettings.cs
@@ -10,6 +10,8 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using NTumbleBit.Tor;
+using TCPServer.Client;
 
 namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 {
@@ -80,10 +82,11 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 			return false;
 		}
 
-		public override HttpMessageHandler CreateHttpHandler()
+		public override HttpMessageHandler CreateHttpHandler(TimeSpan? connectTimeout = null)
 		{
-			var handler = new Tor.SocksMessageHandler(Proxy, new TCPServer.Client.ClientOptions() { IncludeHeaders = false });
-			return handler;
+            var handler = new Tor.SocksMessageHandler(Proxy, new ClientOptions() { IncludeHeaders = false });
+            if (connectTimeout != null) handler.Options.ConnectTimeout = connectTimeout.Value;
+            return handler;
 		}
 	}
 }

--- a/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/SocksConnectionSettings.cs
+++ b/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/SocksConnectionSettings.cs
@@ -85,7 +85,10 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 		public override HttpMessageHandler CreateHttpHandler(TimeSpan? connectTimeout = null)
 		{
             var handler = new Tor.SocksMessageHandler(Proxy, new ClientOptions() { IncludeHeaders = false });
-            if (connectTimeout != null) handler.Options.ConnectTimeout = connectTimeout.Value;
+
+            if (connectTimeout != null)
+                handler.Options.ConnectTimeout = connectTimeout.Value;
+
             return handler;
 		}
 	}

--- a/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/TorConnectionSettings.cs
+++ b/NTumbleBit/ClassicTumbler/Client/ConnectionSettings/TorConnectionSettings.cs
@@ -61,7 +61,7 @@ namespace NTumbleBit.ClassicTumbler.Client.ConnectionSettings
 			get; set;
 		}
 
-		public override HttpMessageHandler CreateHttpHandler()
+		public override HttpMessageHandler CreateHttpHandler(TimeSpan? connectTimeout = null)
 		{
 			throw new NotSupportedException();
 		}

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -70,7 +70,7 @@ namespace NTumbleBit.ClassicTumbler.Client
                     await SetupTorAsync(interaction, configuration.TorPath).ConfigureAwait(false);
                 else if (configuration.TorMandatory)
                     throw new ConfigException("The tumbler server should use TOR");
-                var client = CreateTumblerClient(0, connectTimeout: TimeSpan.FromSeconds(5));
+                var client = CreateTumblerClient(0, connectTimeout: TimeSpan.FromSeconds(15));
                 TumblerParameters = Retry(1, () => client.GetTumblerParameters());
                 if (TumblerParameters == null)
                     throw new ConfigException("Unable to download tumbler's parameters");                

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -70,7 +70,7 @@ namespace NTumbleBit.ClassicTumbler.Client
                     await SetupTorAsync(interaction, configuration.TorPath).ConfigureAwait(false);
                 else if (configuration.TorMandatory)
                     throw new ConfigException("The tumbler server should use TOR");
-                var client = CreateTumblerClient(0);
+                var client = CreateTumblerClient(0, connectTimeout: TimeSpan.FromSeconds(5));
                 TumblerParameters = Retry(1, () => client.GetTumblerParameters());
                 if (TumblerParameters == null)
                     throw new ConfigException("Unable to download tumbler's parameters");                
@@ -200,16 +200,16 @@ namespace NTumbleBit.ClassicTumbler.Client
 			get; set;
 		}
 
-		public TumblerClient CreateTumblerClient(int cycle, Identity? identity = null)
+		public TumblerClient CreateTumblerClient(int cycleId, Identity? identity = null, TimeSpan? connectTimeout = null)
 		{
 			if(identity == null)
 				identity = RandomUtils.GetUInt32() % 2 == 0 ? Identity.Alice : Identity.Bob;
-			return CreateTumblerClient(cycle, identity == Identity.Alice ? AliceSettings : BobSettings);
+			return CreateTumblerClient(cycleId, identity == Identity.Alice ? AliceSettings : BobSettings, connectTimeout);
 		}
 
 		DateTimeOffset previousHandlerCreationDate;
 		TimeSpan CircuitRenewInterval = TimeSpan.FromMinutes(10.0);
-		private TumblerClient CreateTumblerClient(int cycleId, ConnectionSettingsBase settings)
+		private TumblerClient CreateTumblerClient(int cycleId, ConnectionSettingsBase settings, TimeSpan? connectTimeout = null)
 		{
 			if(!AllowInsecure && DateTimeOffset.UtcNow - previousHandlerCreationDate < CircuitRenewInterval)
 			{
@@ -217,7 +217,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			}
 			previousHandlerCreationDate = DateTime.UtcNow;
 			var client = new TumblerClient(Network, TumblerServer, cycleId);
-			var handler = settings.CreateHttpHandler();
+			var handler = settings.CreateHttpHandler(connectTimeout);
 			if(handler != null)
 				client.SetHttpHandler(handler);
 			return client;

--- a/NTumbleBit/Tor/SocksMessageHandler.cs
+++ b/NTumbleBit/Tor/SocksMessageHandler.cs
@@ -72,9 +72,8 @@ namespace NTumbleBit.Tor
 	public class SocksMessageHandler : TCPServer.Client.TCPHttpMessageHandler
 	{
 		static readonly byte[] SelectionMessage = new byte[] { 5, 1, 0 };
-        public static TimeSpan DefaultConnectionTimeout { get; set; } = new ClientOptions().ConnectTimeout;
-        IPEndPoint _SocksEndpoint;
-        public SocksMessageHandler(IPEndPoint socksEndpoint, ClientOptions options = null) : base(options)
+		IPEndPoint _SocksEndpoint;
+		public SocksMessageHandler(IPEndPoint socksEndpoint, ClientOptions options = null) : base(options)
 		{
             _SocksEndpoint = socksEndpoint ?? throw new ArgumentNullException(nameof(socksEndpoint));
 		}
@@ -104,22 +103,6 @@ namespace NTumbleBit.Tor
 					var connectBytes = CreateConnectMessage(endpoint.Host, endpoint.Port);
 					await stream.WriteAsync(connectBytes, 0, connectBytes.Length, cancellation).ConfigureAwait(false);
 					await stream.FlushAsync(cancellation).ConfigureAwait(false);
-
-                    if (Options?.ConnectTimeout != DefaultConnectionTimeout)
-                    {
-                        await Task.Run(() =>
-                        {
-                            DateTime endTime = DateTime.Now.Add(Options.ConnectTimeout);
-                            while (DateTime.Now < endTime)
-                            {
-                                if (stream.DataAvailable) break;
-                                Thread.Sleep(500);
-                            }
-                        });
-
-                        if (!stream.DataAvailable)
-                            throw new SocksException($"No response from the SOCKS proxy has been received within {Options.ConnectTimeout.TotalSeconds} sec");
-                    }
 
 					var connectResponse = await stream.ReadBytes(10, cancellation);
 					if(connectResponse[0] != 5)


### PR DESCRIPTION
ChangeServer call didn't have a logic to attempt a connection to another MasterNode if the randomly selected MasterNode was not available. This code change will enforce the same behaviour in the `ChangeServer`  and `Connect` API calls.