### PR TITLE
update submodule to breeze-beta fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "StratisBitcoinFullNode"]
 	path = StratisBitcoinFullNode
-	url = https://github.com/stratisproject/StratisBitcoinFullNode.git
+	url = https://github.com/breezehub/StratisBitcoinFullNode.git

--- a/Breeze.UI/src/app/login/login.component.html
+++ b/Breeze.UI/src/app/login/login.component.html
@@ -52,7 +52,7 @@
       </div>
       <!-- /row-->
       <div class="row d-flex justify-content-center" *ngIf="hasWallet;else no_wallet">
-        <p class="lead">If you would like to create or restore a wallet please click the button below.
+        <p class="lead">If you would like to create or restore a wallet please click the link below.
           <span class="row d-flex justify-content-center">
             <button type="button" class="btn btn-linkgray btn-lg" (click)="onCreateClicked()">Create or restore a wallet</button>
           </span>

--- a/Breeze.UI/src/app/shared/components/connection-modal/connection-modal.component.html
+++ b/Breeze.UI/src/app/shared/components/connection-modal/connection-modal.component.html
@@ -16,11 +16,11 @@
             </div>
             <div class="form-group row nomargin">
               <label class="col-sm-4 col-form-label">Denomination:</label>
-              <span class="form-control-static col-sm-8"><b>{{ denomination }} {{ coinUnit }}</b></span>
+              <span class="form-control-static col-sm-8"><b>{{ denomination | number:'1.8-8' }} {{ coinUnit }}</b></span>
             </div>
             <div class="form-group row nomargin">
               <label class="col-sm-4 col-form-label">Fees:</label>
-              <span class="form-control-static col-sm-8"><b>{{ fees | number:'1.2-2' }}%</b></span>
+              <span class="form-control-static col-sm-8"><b>{{ fees | number:'1.8-8' }} {{ coinUnit }}</b></span>
             </div>
             <div class="form-group row">
               <label class="col-sm-4 col-form-label">Estimated Time:</label>

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.html
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.html
@@ -24,7 +24,7 @@
             <button type="button" class="btn btn-lg btn-primary mt-4" (click)="startTumbling()" [ngClass]="{ 'btn-disabled': !this.destinationWalletName }" [disabled]="(!isConnected && !tumbling) || !isSynced" *ngIf="!tumbling">Start</button>
             <button type="button" class="btn btn-danger" (click)="stopTumbling()" [disabled]="(!isConnected && tumbling) || !isSynced" *ngIf="tumbling">Stop</button>
             <p class="help mt-4" *ngIf="!isSynced">Please wait until the wallet is fully synced.</p>
-            <p class="help mt-4" *ngIf="!isConnected">Please wait until the wallet is connected.</p>
+            <p class="help mt-4" *ngIf="!isConnected">Please wait until a connection the MasterNode server is established. This can take up to 10min.</p>
             <!-- <p class="help mt-4" *ngIf="!hasRegistrations">Not enough masternodes registered to start the Breeze Privacy Protocol. Please wait.</p> -->
           </form>
 
@@ -53,11 +53,11 @@
             <thead>
               <tr>
                 <th *ngIf="isConnected">
-                  Connection <span class="badge badge-success float-right">Online</span>
+                  Connection <span class="badge badge-success float-right">Connected to MasterNode</span>
                   <a *ngIf="allowChangeServer" class="btn btn-sm btn-secondary" (click)="markAsServerChangeRequired()">Change server</a>
                 </th>
                 <th *ngIf="!isConnected">
-                  Connection <span class="badge badge-danger float-right">Offline</span>
+                  Connection <span class="badge badge-danger float-right">No MasterNode connection</span>
                   <a *ngIf="allowChangeServer" class="btn btn-sm btn-secondary" (click)="markAsServerChangeRequired()">Change server</a>
                 </th>
               </tr>
@@ -107,13 +107,16 @@
           <table class="table" *ngIf="isConnected">
             <tbody>
               <tr>
-                <td><strong>Estimate</strong>{{ estimate | number:'1.2-2' }} Hours</td>
+                <td><strong>Estimate</strong></td>
+				<td>{{ estimate | number:'1.2-2' }} Hours</td>
               </tr>
               <tr>
-                <td><strong>Fee</strong> {{ fee | number:'1.2-2' }}{{ coinUnit }}</td>
+                <td><strong>Fee</strong></td>
+				<td>{{ fee | number:'1.8-8' }} {{ coinUnit }}</td>
               </tr>
               <tr>
-                <td><strong>Denomination</strong> {{ denomination }} {{ coinUnit }}</td>
+                <td><strong>Denomination</strong></td>
+				<td>{{ denomination | number:'1.8-8' }} {{ coinUnit }}</td>
               </tr>
             </tbody>
           </table>

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -327,7 +327,7 @@ export class TumblebitComponent implements OnDestroy {
             this.connectionModal.componentInstance.estimatedTime = this.estimate;
             this.connectionModal.componentInstance.coinUnit = this.coinUnit;
             this.connectionModal.result.then(result => {
-              this.stop();
+              this.stopConnectionRequest();
               if (result === 'skip') {
                 this.markAsServerChangeRequired();
               } else {
@@ -338,7 +338,7 @@ export class TumblebitComponent implements OnDestroy {
         },
         error => {
 
-          this.stop();
+          this.stopConnectionRequest();
           
           console.error(error);
           this.isConnected = false;

--- a/NTumbleBit/ClassicTumbler/Client/StateMachinesExecutor.cs
+++ b/NTumbleBit/ClassicTumbler/Client/StateMachinesExecutor.cs
@@ -148,7 +148,8 @@ namespace NTumbleBit.ClassicTumbler.Client
                             Save(machine);
                         }
 
-                        bool allCyclesAreComplete = ManagedCycles.All(c => c.IsComplete(height));
+                        int numberOfCompletedCycles = ManagedCycles.Count(c => c.IsComplete(height));
+                        bool allCyclesAreComplete = !ManagedCycles.Any() || (numberOfCompletedCycles == ManagedCycles.Count);
                         if (allCyclesAreComplete)
                         {
                             Logs.Client.LogInformation("Tumbling finished; all {0} tumbling cycles have been completed", ManagedCycles.Count);
@@ -157,7 +158,7 @@ namespace NTumbleBit.ClassicTumbler.Client
                         }
                         else
                         {
-                            Logs.Client.LogInformation("Tumbling running; there are {0} of {1} cycles completed", allCyclesAreComplete, ManagedCycles.Count);
+                            Logs.Client.LogDebug("Tumbling running; there are {0} of {1} cycles completed", numberOfCompletedCycles, ManagedCycles.Count);
                         }
 
                         progressInfo.Save();


### PR DESCRIPTION
This is a submodule upgrade of StratisBitcoinFullNode which includes:

* [more verbose logging](https://github.com/stratisproject/StratisBitcoinFullNode/pull/1472)
* [peer re-connection](https://github.com/stratisproject/StratisBitcoinFullNode/pull/1483) 
* Some edits to the re-connection tests, as PeerSelector from March differs in features from SBFN/master HEAD now. Had to pull out peer banning etc.

see sbfn changes here: [https://github.com/DanGould/StratisBitcoinFullNode/tree/breeze-beta]( https://github.com/DanGould/StratisBitcoinFullNode/tree/breeze-beta)