### PR TITLE
Added origin wallet name to the Connect and ChangeServer API

### DIFF
--- a/Breeze.TumbleBit.Client/Controllers/TumbleBitController.cs
+++ b/Breeze.TumbleBit.Client/Controllers/TumbleBitController.cs
@@ -35,8 +35,8 @@ namespace Breeze.TumbleBit.Controllers
         /// Connect to a masternode running the Breeze Privacy Protocol.
         /// </summary>
         [Route("connect")]
-        [HttpGet]
-        public async Task<IActionResult> ConnectAsync()
+        [HttpPost]
+        public async Task<IActionResult> ConnectAsync([FromBody] ConnectRequest request)
         {
             // Checks the request is valid
             if (!this.ModelState.IsValid)
@@ -58,7 +58,7 @@ namespace Breeze.TumbleBit.Controllers
                     ["denomination"] = tumblerParameters.Value.Denomination.ToString(),
                     ["fee"] = tumblerParameters.Value.Fee.ToString(),
                     ["network"] = tumblerParameters.Value.Network.Name,
-                    ["estimate"] = this.tumbleBitManager.CalculateTumblingDuration(),
+                    ["estimate"] = this.tumbleBitManager.CalculateTumblingDuration(request.OriginWalletName),
 					["parameters_are_standard"] = tumblerParameters.Value.IsStandard().ToString()
                 };
 
@@ -104,9 +104,8 @@ namespace Breeze.TumbleBit.Controllers
 		/// Disconnects from the currently connected masternode and attempts to connect to a new one.
 		/// </summary>
 		[Route("changeserver")]
-		[HttpGet]
-		public async Task<IActionResult> 
-		    ChangeServerAsync()
+		[HttpPost]
+		public async Task<IActionResult> ChangeServerAsync([FromBody] ChangeServerRequest request)
 		{
 			// Checks the request is valid
 			if (!this.ModelState.IsValid)
@@ -128,7 +127,7 @@ namespace Breeze.TumbleBit.Controllers
 					["denomination"] = tumblerParameters.Value.Denomination.ToString(),
 					["fee"] = tumblerParameters.Value.Fee.ToString(),
 					["network"] = tumblerParameters.Value.Network.Name,
-					["estimate"] = this.tumbleBitManager.CalculateTumblingDuration(),
+					["estimate"] = this.tumbleBitManager.CalculateTumblingDuration(request.OriginWalletName),
 					["parameters_are_standard"] = tumblerParameters.Value.IsStandard().ToString()
 				};
 

--- a/Breeze.TumbleBit.Client/ITumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/ITumbleBitManager.cs
@@ -64,6 +64,6 @@ namespace Breeze.TumbleBit.Client
         /// Calculates the tumbling duration, based on the origin wallet and various tumbler parameters.   
         /// Returns the days/hours.
         /// </summary>
-        string CalculateTumblingDuration();
+        string CalculateTumblingDuration(string originWalletName);
     }
 }

--- a/Breeze.TumbleBit.Client/Models/RequestModels.cs
+++ b/Breeze.TumbleBit.Client/Models/RequestModels.cs
@@ -38,10 +38,22 @@ namespace Breeze.TumbleBit.Models
         public string OriginWalletPassword { get; set; }
     }
 
-    /// <summary>
-    /// Object used to perform a dummy registration.
-    /// </summary>
-    public class DummyRegistrationRequest : RequestModel
+	public class ConnectRequest : RequestModel
+	{
+		[Required(ErrorMessage = "The name of the origin wallet is required.")]
+		public string OriginWalletName { get; set; }
+	}
+
+	public class ChangeServerRequest : RequestModel
+	{
+		[Required(ErrorMessage = "The name of the origin wallet is required.")]
+		public string OriginWalletName { get; set; }
+	}
+
+	/// <summary>
+	/// Object used to perform a dummy registration.
+	/// </summary>
+	public class DummyRegistrationRequest : RequestModel
     {
         [Required(ErrorMessage = "A wallet name is required.")]
         public string OriginWallet { get; set; }

--- a/Breeze.TumbleBit.Client/Services/FullNodeWalletService.cs
+++ b/Breeze.TumbleBit.Client/Services/FullNodeWalletService.cs
@@ -158,14 +158,16 @@ namespace Breeze.TumbleBit.Client.Services
             return tx;
         }
 
-        /// <summary>
-        /// Retrieves the remaining unspent balance in the origin wallet. Includes unconfirmed transactions.
-        /// </summary>
-        public Money GetBalance()
-        {
-            var unspentOutputs = this.TumblingState.WalletManager.GetSpendableTransactionsInWallet(this.TumblingState.OriginWalletName);
+	    /// <summary>
+	    /// Retrieves the remaining unspent balance in the origin wallet. Includes unconfirmed transactions.
+	    /// </summary>
+	    public Money GetBalance(string walletName = null)
+	    {
+			if (walletName == null)
+				walletName = this.TumblingState.OriginWalletName;
+			var unspentOutputs = this.TumblingState.WalletManager.GetSpendableTransactionsInWallet(walletName);
 
-            return new Money(unspentOutputs.Sum(s => s.Transaction.Amount));
-        }
-    }
+		    return new Money(unspentOutputs.Sum(s => s.Transaction.Amount));
+	    }
+	}
 }

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -784,7 +784,7 @@ namespace Breeze.TumbleBit.Client
             this.TumblingState.Save();
         }
 
-        public string CalculateTumblingDuration()
+        public string CalculateTumblingDuration(string originWalletName)
         {
             if (TumblerParameters == null)
                 return string.Empty;
@@ -800,7 +800,7 @@ namespace Breeze.TumbleBit.Client
             const int cycleDuration = 117;
             const int cycleOverlap = 24;
 
-            var walletBalance = new Money(this.walletManager.GetSpendableTransactionsInWallet(this.TumblingState.OriginWalletName).Sum(s => s.Transaction.Amount));
+            var walletBalance = new Money(this.walletManager.GetSpendableTransactionsInWallet(originWalletName).Sum(s => s.Transaction.Amount));
 
             var demonination = TumblerParameters.Denomination.ToUnit(MoneyUnit.BTC);
             var tumblerFee = TumblerParameters.Fee.ToUnit(MoneyUnit.BTC);

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -21,6 +21,7 @@ using Stratis.Bitcoin.Interfaces;
 using System.IO;
 using NTumbleBit;
 using NTumbleBit.Configuration;
+using NTumbleBit.Logging;
 using Stratis.Bitcoin.Connection;
 using TransactionData = Stratis.Bitcoin.Features.Wallet.TransactionData;
 
@@ -538,7 +539,7 @@ namespace Breeze.TumbleBit.Client
             this.runtime = await TumblerClientRuntime.FromConfigurationAsync(config).ConfigureAwait(false);
 
             // Check if origin wallet has a sufficient balance to begin tumbling at least 1 cycle
-            if (!runtime.HasEnoughFundsForCycle(true))
+            if (!this.runtime.HasEnoughFundsForCycle(true))
             {
                 this.logger.LogDebug("Insufficient funds in origin wallet");
                 throw new Exception("Insufficient funds in origin wallet");
@@ -789,7 +790,7 @@ namespace Breeze.TumbleBit.Client
             if (TumblerParameters == null)
                 return string.Empty;
 
-            /* Tumbling cycles occur up to 117 blocks (cycleDuration) and overlap every 24 blocks (cycleOverlap) :-
+			/* Tumbling cycles occur up to 117 blocks (cycleDuration) and overlap every 24 blocks (cycleOverlap) :-
 
                 Start block	End block
                 ----------- ---------
@@ -797,25 +798,37 @@ namespace Breeze.TumbleBit.Client
                 24	        141
                 48	        165
              */
-            const int cycleDuration = 117;
+			const int cycleDuration = 117;
             const int cycleOverlap = 24;
 
-            var walletBalance = new Money(this.walletManager.GetSpendableTransactionsInWallet(originWalletName).Sum(s => s.Transaction.Amount));
+	        Money walletBalance = this.runtime.Services.WalletService.GetBalance(originWalletName);
+	        FeeRate networkFeeRate = this.runtime.Services.FeeService.GetFeeRateAsync().GetAwaiter().GetResult();
 
-            var demonination = TumblerParameters.Denomination.ToUnit(MoneyUnit.BTC);
-            var tumblerFee = TumblerParameters.Fee.ToUnit(MoneyUnit.BTC);
-            var networkFee = new Money(TumblerParameters.Network.MinTxFee).ToUnit(MoneyUnit.BTC);
+			if (!this.HasEnoughFundsForCycle(true, originWalletName))
+		        return TimeSpanInWordFormat(0);
+
+			var demonination = TumblerParameters.Denomination;
+            var tumblerFee = TumblerParameters.Fee;
+	        var networkFee = networkFeeRate.GetFee(TumblerClientRuntime.AverageClientEscrowTransactionSizeInBytes);
 
             var cycleCost = demonination + tumblerFee + networkFee;
 
-            var numberOfCycles = Math.Truncate(walletBalance.ToUnit(MoneyUnit.BTC) / cycleCost);
+            var numberOfCycles = Math.Truncate(walletBalance.ToUnit(MoneyUnit.BTC) / cycleCost.ToDecimal(MoneyUnit.BTC));
             var durationInBlocks = cycleDuration + ((numberOfCycles - 1) * cycleOverlap);
             var durationInHours = durationInBlocks * 10 / 60;
 
-            return TimeSpanInWordFormat(durationInHours.ToString(CultureInfo.InvariantCulture)); ;
+            return TimeSpanInWordFormat(durationInHours);
         }
 
-        public void Dispose()
+	    public bool HasEnoughFundsForCycle(bool firstCycle, string originWalletName)
+	    {
+			Money walletBalance = this.runtime.Services.WalletService.GetBalance(originWalletName);
+		    FeeRate networkFeeRate = this.runtime.Services.FeeService.GetFeeRateAsync().GetAwaiter().GetResult();
+
+		    return TumblerClientRuntime.HasEnoughFundsForCycle(firstCycle, walletBalance, networkFeeRate, TumblerParameters.Denomination, TumblerParameters.Fee);
+	    }
+
+		public void Dispose()
         {
             if (this.broadcasterJob != null && this.broadcasterJob.Started)
             {
@@ -847,12 +860,12 @@ namespace Breeze.TumbleBit.Client
             }
         }
 
-        private static string TimeSpanInWordFormat(string fromHours)
+        private static string TimeSpanInWordFormat(decimal fromHours)
         {
-            if (!double.TryParse(fromHours, out var parsedHours))
-                return string.Empty;
+	        if (fromHours == 0)
+		        return "N/A";
 
-            var timeSpan = TimeSpan.FromHours(parsedHours);
+            var timeSpan = TimeSpan.FromHours((double)fromHours);
 
             var days = timeSpan.Days.ToString();
             var hours = timeSpan.Hours.ToString();

--- a/Breeze.UI/src/app/wallet/tumblebit/classes/connect-request.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/classes/connect-request.ts
@@ -1,0 +1,8 @@
+export class ConnectRequest {
+
+    constructor(originWalletName: string) {
+      this.OriginWalletName = originWalletName;
+    }
+
+    OriginWalletName: string;
+  }

--- a/Breeze.UI/src/app/wallet/tumblebit/classes/connect-request.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/classes/connect-request.ts
@@ -1,8 +1,4 @@
 export class ConnectRequest {
 
-    constructor(originWalletName: string) {
-      this.OriginWalletName = originWalletName;
-    }
-
-    OriginWalletName: string;
+    constructor(public OriginWalletName: string) {}
   }

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -18,6 +18,7 @@ import { Error } from '../../shared/classes/error';
 import { TumblebitService } from './tumblebit.service';
 import { TumblerConnectionRequest } from './classes/tumbler-connection-request';
 import { TumbleRequest } from './classes/tumble-request';
+import { ConnectRequest } from './classes/connect-request';
 import { CycleInfo } from './classes/cycle-info';
 import { ModalService } from '../../shared/services/modal.service';
 import { CompositeDisposable } from '../../shared/classes/composite-disposable';
@@ -312,8 +313,12 @@ export class TumblebitComponent implements OnDestroy {
       this.connectionSubscription.unsubscribe();
     }
 
+    const connectRequest = new ConnectRequest(
+      this.sourceWalletName = this.globalService.getWalletName(),
+    )	
+	
     this.connectionSubscription = this.tumblebitService
-      .connectToTumbler(this.operation)
+      .connectToTumbler(this.operation, connectRequest)
       .subscribe(
         // TODO abstract into shared utility method
         response => {

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -314,8 +314,8 @@ export class TumblebitComponent implements OnDestroy {
     }
 
     const connectRequest = new ConnectRequest(
-      this.sourceWalletName = this.globalService.getWalletName(),
-    )	
+      this.globalService.getWalletName()
+    );
 	
     this.connectionSubscription = this.tumblebitService
       .connectToTumbler(this.operation, connectRequest)

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.component.ts
@@ -329,7 +329,7 @@ export class TumblebitComponent implements OnDestroy {
             this.estimate = this.tumblerParameters.estimate;
             this.fee = this.tumblerParameters.fee;
             this.denomination = this.tumblerParameters.denomination;
-            this.parametersAreStandard = this.tumblerParameters.parameters_are_standard;
+            this.parametersAreStandard = this.tumblerParameters.parameters_are_standard.toLowerCase() === "true";
 
             if (!!this.connectionModal) {
               this.connectionModal.dismiss();

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
@@ -9,7 +9,7 @@ import 'rxjs/add/observable/throw';
 
 import { TumblerConnectionRequest } from './classes/tumbler-connection-request';
 import { TumbleRequest } from './classes/tumble-request';
-import { ConnectRequest } from '../classes/connect-request';
+import { ConnectRequest } from './classes/connect-request';
 import { GlobalService } from '../../shared/services/global.service';
 
 @Injectable()

--- a/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
+++ b/Breeze.UI/src/app/wallet/tumblebit/tumblebit.service.ts
@@ -9,6 +9,7 @@ import 'rxjs/add/observable/throw';
 
 import { TumblerConnectionRequest } from './classes/tumbler-connection-request';
 import { TumbleRequest } from './classes/tumble-request';
+import { ConnectRequest } from '../classes/connect-request';
 import { GlobalService } from '../../shared/services/global.service';
 
 @Injectable()
@@ -27,9 +28,9 @@ export class TumblebitService {
 
   // Might make sense to populate tumblerParams here because services are singletons
 
-  connectToTumbler(operation: 'connect' | 'changeserver'): Observable<any> {
+  connectToTumbler(operation: 'connect' | 'changeserver', body: ConnectRequest): Observable<any> {
     return this.http
-      .get(`${this.tumblerClientUrl}${operation}`)
+      .post(`${this.tumblerClientUrl}${operation}`, JSON.stringify(body), {headers: this.headers})
       .retryWhen(e => {
         return e
            .mergeMap((error: any) => {
@@ -44,9 +45,9 @@ export class TumblebitService {
       .map((response: Response) => response);
   };
 
-  changeTumblerServer(): Observable<any> {
+  changeTumblerServer(body: ConnectRequest): Observable<any> {
     return this.http
-      .get(`${this.tumblerClientUrl}changeserver`)
+      .post(`${this.tumblerClientUrl}changeserver`, JSON.stringify(body), {headers: this.headers})
       .retryWhen(e => {
         return e
            .mergeMap((error: any) => {

--- a/NTumbleBit/Services/IWalletService.cs
+++ b/NTumbleBit/Services/IWalletService.cs
@@ -11,6 +11,6 @@ namespace NTumbleBit.Services
         Task<IDestination> GenerateAddressAsync();
         Task<Transaction> FundTransactionAsync(TxOut txOut, FeeRate feeRate);
         Task<Transaction> ReceiveAsync(ScriptCoin escrowedCoin, TransactionSignature clientSignature, Key escrowKey, FeeRate feeRate);
-        Money GetBalance();
+        Money GetBalance(string walletName = null);
     }
 }

--- a/NTumbleBit/Services/RPC/RPCWalletService.cs
+++ b/NTumbleBit/Services/RPC/RPCWalletService.cs
@@ -114,7 +114,7 @@ namespace NTumbleBit.Services.RPC
             return await task;
         }
 
-        public Money GetBalance()
+        public Money GetBalance(string walletName = null)
         {
             // This was introduced for the Breeze version of the services only; included to silence an error
             throw new NotImplementedException();


### PR DESCRIPTION
In order to calculate tumbling duration of full wallet balance the Connect/ChangeServer API needs to have name of the origin wallet.
There is additional check for the minimum wallet balance required for tumbling which is executed when we return Tumbler Server parameters.