### PR TITLE
Improvements to the DBreezeUtils

### DIFF
--- a/Breeze.TumbleBit.Client.DBreezeUtils/DBreezeUtils.cs
+++ b/Breeze.TumbleBit.Client.DBreezeUtils/DBreezeUtils.cs
@@ -30,7 +30,7 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
         }
     }
     
-    public class DBreezeUtils
+    public class DBreezeUtils : IDisposable
     {
         private string _path;
         private DBreezeRepository _repository;
@@ -42,6 +42,11 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
             _repository = new DBreezeRepository(path);
             _network = network;
         }
+
+	    public void Dispose()
+	    {
+		    _repository.Dispose();
+		}
 
         public List<string> GetServerAddresses()
         {

--- a/Breeze.TumbleBit.Client.DBreezeUtils/Program.cs
+++ b/Breeze.TumbleBit.Client.DBreezeUtils/Program.cs
@@ -20,17 +20,24 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
             // args[0] = path to folder containing db2 directory & wallet jsons
             // args[1] = origin wallet filename
             // args[2] = destination wallet filename
+			// args[3] = short output
             
-            //string repoPath = Path.Combine(args[0], "db2");
-            string repoPath = Path.Combine(@"C:\Users\Kevin\Downloads\Projects\TBdata\regtest17", "db2_server");
+            string repoPath = Path.Combine(args[0], "TumbleBit\\db2");
             var network = Network.RegTest;
             var api = (network != Network.RegTest ? new SmartBitApi(network) : null);
             var repo = new DBreezeUtils(repoPath, network);
-            //var walletUtils = new WalletUtils(args[0], args[1], args[2]);
-            var walletUtils = new WalletUtils(@"C:\Users\Kevin\Downloads\Projects\TBdata\regtest17", "alice.wallet.json", "bob.wallet.json");
+            var walletUtils = new WalletUtils(args[0], args[1], args[2]);
+
             var textOutput = new TextOutput(repo, api, walletUtils);
             
             textOutput.DumpServers();
+	        if (args.Length >= 4 && args[3] == "-s")
+	        {
+		        textOutput.DumpCycleTransactionsShort();
+		        repo.Dispose();
+				return;
+	        }
+
             textOutput.DumpCycleTransactions(false);
             
             Console.WriteLine("=====");
@@ -135,6 +142,7 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
                 }
             }
 
+			repo.Dispose();
             Console.ReadLine();
         }
     }

--- a/Breeze.TumbleBit.Client.DBreezeUtils/TextOutput.cs
+++ b/Breeze.TumbleBit.Client.DBreezeUtils/TextOutput.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Breeze.TumbleBit.Client.Services;
 using NTumbleBit.Services;
+using Stratis.Bitcoin.Features.Wallet;
 
 namespace Breeze.TumbleBit.Client.DBreezeUtils
 {
@@ -24,73 +25,140 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
                 Console.WriteLine("Server: " + server);
             }
         }
-        
-        public void DumpCycleTransactions(bool apiLookup)
-        {
-            Console.WriteLine("=====");
-            var separator = ",";
-            Console.WriteLine("CycleNumber, RecordType, TransactionType, TransactionId, InWallets, IsBroadcasted");
-            foreach (var cycle in repo.GetCycles())
-            {
-                Console.WriteLine("Cycle: " + cycle);
-                foreach (var record in repo.GetCycleRecords(cycle))
-                {
-                    // Only interested in transaction records
-                    if (record.RecordType == RecordType.ScriptPubKey)
-                        continue;
-                    
-                    Console.Write(cycle);
-                    Console.Write(separator);
-                    Console.Write(record.RecordType);
-                    Console.Write(separator);
-                    Console.Write(record.TransactionType);
-                    Console.Write(separator);
-                    
-                    if (record.TransactionId == null)
-                        Console.Write("null");
-                    else
-                        Console.Write(record.TransactionId);
-                    
-                    //Console.Write(separator);
-                    //Console.Write(record.ScriptPubKey);
 
-                    Console.Write(separator);
-                    
-                    if (walletUtils.FindTransaction(record.TransactionId.ToString()))
-                        Console.Write("true");
-                    else
-                        Console.Write("false");
-                    
-                    Console.Write(separator);
-                    
-                    if (apiLookup)
-                    {
-                        string status = "";
+		public void DumpCycleTransactions(bool apiLookup)
+		{
+			Console.WriteLine("=====");
+			var separator = ",";
+			Console.WriteLine("CycleNumber, RecordType, TransactionType, TransactionId, InWallets, IsBroadcasted");
+			foreach (var cycle in repo.GetCycles())
+			{
+				Console.WriteLine("Cycle: " + cycle);
+				foreach (var record in repo.GetCycleRecords(cycle))
+				{
+					// Only interested in transaction records
+					if (record.RecordType == RecordType.ScriptPubKey)
+						continue;
 
-                        try
-                        {
-                            var result = api.GetTransaction(record.TransactionId.ToString()).Result;
+					Console.Write(cycle);
+					Console.Write(separator);
+					Console.Write(record.RecordType);
+					Console.Write(separator);
+					Console.Write(record.TransactionType);
+					Console.Write(separator);
 
-                            if (result.State == SmartBitResultState.Success)
-                                status = "broadcasted";
-                            else if (result.State == SmartBitResultState.Failure)
-                            {
-                                status = "unbroadcasted";
-                            }
-                            else
-                                status = "unknown";
-                        }
-                        catch (Exception)
-                        {
-                            status = "unknown";
-                        }
+					if (record.TransactionId == null)
+						Console.Write("null");
+					else
+						Console.Write(record.TransactionId);
 
-                        Console.Write(status);
-                    }
-                    
-                    Console.Write(Environment.NewLine);
-                }
-            }
-        }
-    }
+					//Console.Write(separator);
+					//Console.Write(record.ScriptPubKey);
+
+					Console.Write(separator);
+
+					if (walletUtils.TransactionExistsInWallet(record.TransactionId.ToString()))
+						Console.Write("true");
+					else
+						Console.Write("false");
+
+					Console.Write(separator);
+
+					if (apiLookup)
+					{
+						string status = "";
+
+						try
+						{
+							var result = api.GetTransaction(record.TransactionId.ToString()).Result;
+
+							if (result.State == SmartBitResultState.Success)
+								status = "broadcasted";
+							else if (result.State == SmartBitResultState.Failure)
+							{
+								status = "unbroadcasted";
+							}
+							else
+								status = "unknown";
+						}
+						catch (Exception)
+						{
+							status = "unknown";
+						}
+
+						Console.Write(status);
+					}
+
+					Console.Write(Environment.NewLine);
+				}
+			}
+		}
+
+
+		public void DumpCycleTransactionsShort()
+		{
+			Console.WriteLine("=====");
+			var separator = ",";
+			Console.WriteLine("CycleNumber, RecordType, TransactionType, TransactionId, InWallets, IsBroadcasted");
+
+			foreach (var cycle in repo.GetCycles())
+			{
+				bool hasClientEscrow = false;
+				bool hasClientRedeem = false;
+				bool hasTumblerCashout = false;
+				foreach (var record in repo.GetCycleRecords(cycle))
+				{
+					if (record.RecordType == RecordType.ScriptPubKey)
+						continue;
+
+					TransactionData transaction = walletUtils.FindTransaction(record.TransactionId.ToString());
+					bool transactionExistsInWallet = transaction != null;
+					bool transactionIsConfirmed = transaction != null ? transaction.IsConfirmed() : false;
+
+					if (record.TransactionType == TransactionType.ClientEscrow && transactionExistsInWallet && transactionIsConfirmed)
+						hasClientEscrow = true;
+					if (record.TransactionType == TransactionType.ClientRedeem && transactionExistsInWallet && transactionIsConfirmed)
+						hasClientRedeem = true;
+					if (record.TransactionType == TransactionType.TumblerCashout && transactionExistsInWallet && transactionIsConfirmed)
+						hasTumblerCashout = true;
+				}
+
+				if (!hasClientEscrow || (hasClientRedeem && !hasTumblerCashout) || (!hasClientRedeem && hasTumblerCashout)) continue;
+
+				Console.Write("Cycle: " + cycle);
+				if (hasClientRedeem && hasTumblerCashout)
+					Console.WriteLine(" (ClientRedeem and TumblerCashout transactions have been used)");
+				if (!hasClientRedeem && !hasTumblerCashout)
+					Console.WriteLine(" (Lost funds, no transactions have been used)");
+
+				foreach (var record in repo.GetCycleRecords(cycle))
+				{
+					// Only interested in transaction records
+					if (record.RecordType == RecordType.ScriptPubKey)
+						continue;
+
+					Console.Write(cycle);
+					Console.Write(separator);
+					Console.Write(record.RecordType);
+					Console.Write(separator);
+					Console.Write(record.TransactionType);
+					Console.Write(separator);
+
+					if (record.TransactionId == null)
+						Console.Write("null");
+					else
+						Console.Write(record.TransactionId);
+
+					Console.Write(separator);
+
+					if (walletUtils.TransactionExistsInWallet(record.TransactionId.ToString()))
+						Console.Write("true");
+					else
+						Console.Write("false");
+
+					Console.WriteLine();
+				}
+			}
+		}
+	}
 }

--- a/Breeze.TumbleBit.Client.DBreezeUtils/WalletUtils.cs
+++ b/Breeze.TumbleBit.Client.DBreezeUtils/WalletUtils.cs
@@ -19,22 +19,27 @@ namespace Breeze.TumbleBit.Client.DBreezeUtils
             _coinType = coinType;
         }
 
-        public bool FindTransaction(string txId)
-        {
-            foreach (var tx in _sourceWallet.GetAllTransactionsByCoinType(_coinType))
-            {
-                if (tx.Id.ToString().Equals(txId))
-                    return true;
-            }
+	    public TransactionData FindTransaction(string txId)
+	    {
+		    foreach (var tx in _sourceWallet.GetAllTransactionsByCoinType(_coinType))
+		    {
+			    if (tx.Id.ToString().Equals(txId))
+				    return tx;
+		    }
 
-            foreach (var tx in _destWallet.GetAllTransactionsByCoinType(_coinType))
-            {
-                if (tx.Id.ToString().Equals(txId))
-                    return true;
-            }
+		    foreach (var tx in _destWallet.GetAllTransactionsByCoinType(_coinType))
+		    {
+			    if (tx.Id.ToString().Equals(txId))
+				    return tx;
+		    }
 
-            return false;
-        }
+		    return null;
+	    }
+
+		public bool TransactionExistsInWallet(string txId)
+		{
+			return FindTransaction(txId) != null;
+		}
 
         /*
         public Money GetFee(string txId)


### PR DESCRIPTION
Introduces additional command line switch which will list only cycles which do not have a propagated and confirmed **ClientRedeem** or **TumblerCashout** transactions