### PR TITLE
Stop tumbling when there is not enough peers

### DIFF
--- a/Breeze.TumbleBit.Client/Services/FullNodeBlockExplorerService.cs
+++ b/Breeze.TumbleBit.Client/Services/FullNodeBlockExplorerService.cs
@@ -148,5 +148,10 @@ namespace Breeze.TumbleBit.Client.Services
 
             return true;
         }
+
+	    public int GetConnectionCount()
+	    {
+		    return this.TumblingState.ConnectionManager.ConnectedPeers.Count();
+	    }
     }
 }

--- a/Breeze.UI/package.json
+++ b/Breeze.UI/package.json
@@ -1,13 +1,13 @@
 {
   "name": "Breeze",
   "description": "Graphical User Interface for Breeze Wallet.",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "author": {
     "name": "Breeze Team",
     "email": "support@stratisplatform.com"
   },
   "license": "MIT",
-  "homepage": "https://github.com/stratisproject/breeze",
+  "homepage": "https://github.com/BreezeHub/BreezeProject",
   "keywords": [
     "breeze",
     "ui",

--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -455,6 +455,14 @@ namespace NTumbleBit.ClassicTumbler.Client
                                 Logs.Client.LogDebug("Still solving puzzles...");
                                 break;
                             }
+
+							int connectionCount = Services.BlockExplorerService.GetConnectionCount();
+							if (connectionCount < 4)
+							{
+								Logs.Client.LogWarning("There are too few bitcoin peers connected; payment will not be processed");
+								break;
+							}
+
                             var revelation2 = SolverClientSession.Reveal(commitments);
                             var solutionKeys = alice.CheckRevelation(SolverClientSession.Id, revelation2);
                             var blindFactors = SolverClientSession.GetBlindFactors(solutionKeys);

--- a/NTumbleBit/Services/IBlockExplorerService.cs
+++ b/NTumbleBit/Services/IBlockExplorerService.cs
@@ -32,5 +32,6 @@ namespace NTumbleBit.Services
 		Task TrackAsync(Script scriptPubkey);
 		int GetBlockConfirmations(uint256 blockId);
 		Task<bool> TrackPrunedTransactionAsync(Transaction transaction, MerkleBlock merkleProof);
-	}
+	    int GetConnectionCount();
+    }
 }

--- a/NTumbleBit/Services/RPC/RPCBlockExplorerService.cs
+++ b/NTumbleBit/Services/RPC/RPCBlockExplorerService.cs
@@ -258,5 +258,10 @@ namespace NTumbleBit.Services.RPC
 			}).ConfigureAwait(false);
 			return success;
 		}
+
+		public int GetConnectionCount()
+		{
+			throw new NotImplementedException("Method GetConnectionCount is not implemented in RPCBlockExplorerService");
+		}
 	}
 }


### PR DESCRIPTION
When the node looses a connection to the bitcoin peers in the Payment Phase it might fail to broadcast TumblerCashout transaction before the Bob's escrow timelock. In that case the masternode will "steel" bob's money.
In order to address this the node will confirm that it has at least 4 peers on the bitcoin network before engaging in the final payment phase with the masternode. 