### PR TITLE
Standard server check

### DIFF
--- a/Breeze.TumbleBit.Client/Controllers/TumbleBitController.cs
+++ b/Breeze.TumbleBit.Client/Controllers/TumbleBitController.cs
@@ -124,7 +124,7 @@ namespace Breeze.TumbleBit.Controllers
 
                 var parameterDictionary = new Dictionary<string, string>()
                 {
-                    ["tumbler"] = this.tumbleBitManager.TumblerAddress,
+                    ["tumbler"] = this.tumbleBitManager.TumblerDisplayAddress,
                     ["denomination"] = tumblerParameters.Value.Denomination.ToString(),
                     ["fee"] = tumblerParameters.Value.Fee.ToString(),
                     ["network"] = tumblerParameters.Value.Network.Name,

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -305,6 +305,13 @@ namespace Breeze.TumbleBit.Client
                 // This is overwritten by the tumble method, but it is needed at the beginning of that method for the balance check
                 this.TumblerParameters = rt.TumblerParameters;
 
+                //Check if the Server parameters are standard and do not connect if the parameters are non-standard
+                if (!rt.TumblerParameters.IsStandard())
+                {
+                    this.logger.LogDebug($"Refusing to connect to the non-standard MasterNode {this.TumblerAddress}");
+                    return Result.Fail<ClassicTumblerParameters>($"Cannot connect to the MasterNode server {this.TumblerAddress} because its parameters are non-standard.", PostResultActionType.CanContinue);
+                }
+
                 return Result.Ok(rt.TumblerParameters);
             }
             catch (PrivacyProtocolConfigException e)

--- a/Breeze.UI/package.json
+++ b/Breeze.UI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Breeze",
   "description": "Graphical User Interface for Breeze Wallet.",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "author": {
     "name": "Breeze Team",
     "email": "support@stratisplatform.com"

--- a/NTumbleBit/ClassicTumbler/ClassicTumblerParameters.cs
+++ b/NTumbleBit/ClassicTumbler/ClassicTumblerParameters.cs
@@ -225,7 +225,7 @@ namespace NTumbleBit.ClassicTumbler
                 this.RealPuzzleCount == 15 &&
                 this.RealTransactionCount == 42 &&
                 this.FakeTransactionCount == 42 &&
-                this.Denomination == new Money(0.02m, MoneyUnit.BTC) &&
+                this.Denomination == new Money(0.1m, MoneyUnit.BTC) &&
                 this.Fee == new Money(0.00075m, MoneyUnit.BTC) &&
                 this.FakeFormat == new uint256(Enumerable.Range(0, 32).Select(o => o == 0 ? (byte) 0 : (byte) 1).ToArray());
         }


### PR DESCRIPTION
When connecting to the MasterNode the `Connect` and `ChangeServer` APIs will verify that the server have standard parameters. If the server is non-standard the connection will be dimmed unsuccessful and attempt will be made to connect to another MasterNode.